### PR TITLE
Converts project to use preact

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,40 @@
+const withPrefresh = require('@prefresh/next')
+
+module.exports = withPrefresh({
+  webpack(config, { dev, isServer }) {
+    // Move Preact into the framework chunk instead of duplicating in routes:
+    const splitChunks = config.optimization && config.optimization.splitChunks
+    if (splitChunks) {
+      const cacheGroups = splitChunks.cacheGroups
+      const test = /[\\/]node_modules[\\/](preact|preact-render-to-string|preact-context-provider)[\\/]/
+      if (cacheGroups.framework) {
+        cacheGroups.preact = Object.assign({}, cacheGroups.framework, { test })
+        // if you want to merge the 2 small commons+framework chunks:
+        // cacheGroups.commons.name = 'framework';
+      }
+    }
+
+    if (isServer) {
+      // mark `preact` stuffs as external for server bundle to prevent duplicate copies of preact
+      config.externals.push(
+        /^(preact|preact-render-to-string|preact-context-provider)([\\/]|$)/
+      )
+    }
+
+    // Install webpack aliases:
+    const aliases = config.resolve.alias || (config.resolve.alias = {})
+    aliases.react = aliases['react-dom'] = 'preact/compat'
+
+    // Automatically inject Preact DevTools:
+    if (dev && !isServer) {
+      const entry = config.entry
+      config.entry = () =>
+        entry().then((entries) => {
+          entries['main.js'] = ['preact/debug'].concat(entries['main.js'] || [])
+          return entries
+        })
+    }
+
+    return config
+  },
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -2375,6 +2375,25 @@
       "resolved": "https://registry.npmjs.org/@next/react-refresh-utils/-/react-refresh-utils-9.5.3.tgz",
       "integrity": "sha512-W3VKOqbg+4Kw+k6M/SODf+WIzwcx60nAemGV1nNPa/yrDtAS2YcJfqiswrJ3+2nJHzqefAFWn4XOfM0fy8ww2Q=="
     },
+    "@prefresh/core": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@prefresh/core/-/core-0.7.4.tgz",
+      "integrity": "sha512-Qbdjg0xH7svik4ErxMLcJUblEoi1qKt/Je3qsHqLdZjtsU4/BWW6oOtz4COAZK5KirpFS56VjBYMLzi6/ueZqQ=="
+    },
+    "@prefresh/next": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@prefresh/next/-/next-0.3.2.tgz",
+      "integrity": "sha512-HpsMsqyjVHsn2/U1AWHneBN28rhmPQHTyYRaOzbZ3yz89s2WSpsEdZWkTZM5aVRqh1d2gy9eEhS0lVxjPzYPTg==",
+      "requires": {
+        "@prefresh/core": "^0.7.2",
+        "@prefresh/utils": "^0.2.1"
+      }
+    },
+    "@prefresh/utils": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@prefresh/utils/-/utils-0.2.1.tgz",
+      "integrity": "sha512-Ju7WHncqUKsaFp7yAFoNSR2jdr0bjqr8AwV06LtpFmwliPe4IDGRcBGhofg+SY9yld3FUF1JWmEoUOfCyCGRhA=="
+    },
     "@sinonjs/commons": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
@@ -10166,6 +10185,26 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
       "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ=="
     },
+    "preact": {
+      "version": "10.5.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.5.2.tgz",
+      "integrity": "sha512-4y2Q6kMiJtMONMJR7z+o8P5tGkMzVItyy77AXGrUdusv+dk4jwoS3KrpCBkFloY2xsScRJYwZQZrx89tTjDkOw=="
+    },
+    "preact-render-to-string": {
+      "version": "5.1.10",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-5.1.10.tgz",
+      "integrity": "sha512-40svy7NDe5Qe0ymdsIC11f0hZb05MeTSUqqIaWJ5DEFCh/sF86KcpRW0kN/ymGYDVVUCfv9qFrVuLCXR7aQxgQ==",
+      "requires": {
+        "pretty-format": "^3.8.0"
+      },
+      "dependencies": {
+        "pretty-format": {
+          "version": "3.8.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
+          "integrity": "sha1-v77VbV6ad2ZF9LH/eqGjrE+jw4U="
+        }
+      }
+    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -10399,25 +10438,12 @@
       }
     },
     "react": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
-      "integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
-      }
+      "version": "github:preact-compat/react#acfe2cc2acc677d08fb8edf8ce04796634d8edf8",
+      "from": "github:preact-compat/react#1.0.0"
     },
     "react-dom": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
-      "integrity": "sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==",
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.19.1"
-      }
+      "version": "github:preact-compat/react-dom#75804a834f55de5350c175f9646631dabac258ae",
+      "from": "github:preact-compat/react-dom#1.0.0"
     },
     "react-is": {
       "version": "16.13.1",
@@ -10436,6 +10462,11 @@
       "requires": {
         "prop-types": "^15.6.2"
       }
+    },
+    "react-ssr-prepass": {
+      "version": "npm:preact-ssr-prepass@1.1.1",
+      "resolved": "https://registry.npmjs.org/preact-ssr-prepass/-/preact-ssr-prepass-1.1.1.tgz",
+      "integrity": "sha512-AszER25gPq8GMcUP+PruRCRg6FEgeoVfR8tlquz7QCPbRLSqkmHkTNwRiwx0zeRl0wd0CtFN4D9r6zCPeVo8Hg=="
     },
     "read-pkg": {
       "version": "5.2.0",
@@ -10926,15 +10957,6 @@
       "dev": true,
       "requires": {
         "xmlchars": "^2.2.0"
-      }
-    },
-    "scheduler": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
       }
     },
     "schema-utils": {

--- a/package.json
+++ b/package.json
@@ -13,12 +13,16 @@
   "author": "Tianhui Michael Li",
   "license": "ISC",
   "dependencies": {
+    "@prefresh/next": "^0.3.0",
     "@emotion/core": "^10.0.35",
     "@emotion/styled": "^10.0.27",
     "next": "^9.5.3",
     "normalize.css": "^8.0.1",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1",
+    "preact": "^10.4.4",
+    "preact-render-to-string": "^5.1.9",
+    "react": "github:preact-compat/react#1.0.0",
+    "react-dom": "github:preact-compat/react-dom#1.0.0",
+    "react-ssr-prepass": "npm:preact-ssr-prepass@^1.0.1",
     "react-social-icons": "^4.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
We fake that React is still present with aliases so external libraries like `react-social-icons` can be used without problems.

Let me know if you run into any issues with these changes (tested here with `npm run start` and everything worked)